### PR TITLE
Fix spell name; Remove outdated event registration

### DIFF
--- a/ButtonForge/EventManager.lua
+++ b/ButtonForge/EventManager.lua
@@ -137,7 +137,7 @@ Usable:RegisterEvent("UPDATE_VEHICLE_ACTIONBAR");
 Usable:RegisterEvent("ACTIONBAR_UPDATE_USABLE");	--Use this as a backup...
 Usable:RegisterEvent("VEHICLE_UPDATE");
 Usable:RegisterEvent("ACTIONBAR_PAGE_CHANGED");	
-Usable:RegisterEvent("UPDATE_WORLD_STATES");	
+--Usable:RegisterEvent("UPDATE_WORLD_STATES");	
 
 
 --[[------------------------------------------------------------------------

--- a/ButtonForge/Util.lua
+++ b/ButtonForge/Util.lua
@@ -1661,9 +1661,7 @@ end
 	Spell Functions
 -------------------------------------------]]
 function Util.GetFullSpellName(Name, Rank)
-	if (Name) then
-		return Name.."("..Rank..")";
-	end
+	return Name;
 end
 
 function Util.GetSpellId(NameRank)


### PR DESCRIPTION
This PR fixes this mod so it can work properly with the latest version of WoW (8.0.1).  The fixes are:

1. Spell names no longer take a rank, so that has been removed when getting the spell name to cast.
1. UPDATE_WORLD_STATES is no longer an event that can be registered for.

> **NOTE**: The version of the mod currently available via Twitch/Curse is outdated and also includes a bug for playing sounds.  This bug is already fixed here on GitHub, so we may want to get a newer version of this mod released for players to use.